### PR TITLE
Fixed error format index

### DIFF
--- a/djangocms_instagram/models.py
+++ b/djangocms_instagram/models.py
@@ -240,7 +240,7 @@ class Instagram(CMSPlugin):
                         media.extend(media_feed)
 
             except (InstagramAPIError, InstagramClientError) as e:
-                msg = _('Failed to retrieve media - Reason: {}').format(e)
+                msg = _('Failed to retrieve media - Reason: {error_msg}').format(error_msg=e)
                 logger.error(msg)
             else:
                 cache.set(cache_key, media, settings.DJANGOCMS_INSTAGRAM_CACHE_DURATION)

--- a/djangocms_instagram/models.py
+++ b/djangocms_instagram/models.py
@@ -240,7 +240,7 @@ class Instagram(CMSPlugin):
                         media.extend(media_feed)
 
             except (InstagramAPIError, InstagramClientError) as e:
-                msg = _('Failed to retrieve media - Reason: {1}').format(e)
+                msg = _('Failed to retrieve media - Reason: {}').format(e)
                 logger.error(msg)
             else:
                 cache.set(cache_key, media, settings.DJANGOCMS_INSTAGRAM_CACHE_DURATION)


### PR DESCRIPTION
When retrieving data from instagram but it failes, for what ever reason, the error logger breaks the execution because of a syntax error with str().format().
